### PR TITLE
Add simple front-end simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # melo-app
 Repositorio de desarrollo de Melo App
+
+## Simulador
+
+Incluye un simulador simple en HTML, CSS y JavaScript para elegir paquetes de limpieza y toppings adicionales. Abre `index.html` en tu navegador para probarlo.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MELOAPP</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <main class="container">
+        <h1>MELOAPP</h1>
+        <section class="packages">
+            <h2>Selecciona tu paquete</h2>
+            <div class="package-list">
+                <!-- Packages will be injected here by JS or we can define them in HTML with labels and inputs-->
+                <label class="package-card" data-price="25">
+                    <input type="radio" name="package" value="SMART" />
+                    <span class="emoji">🟠</span>
+                    <span class="name">Paquete SMART</span>
+                    <span class="price">$25</span>
+                </label>
+                <label class="package-card" data-price="35">
+                    <input type="radio" name="package" value="FRESCOS" />
+                    <span class="emoji">🟢</span>
+                    <span class="name">Esenciales Frescos</span>
+                    <span class="price">$35</span>
+                </label>
+                <label class="package-card" data-price="45">
+                    <input type="radio" name="package" value="RENACERES" />
+                    <span class="emoji">🟡</span>
+                    <span class="name">Renaceres MELO</span>
+                    <span class="price">$45</span>
+                </label>
+                <label class="package-card" data-price="40">
+                    <input type="radio" name="package" value="MIMOS" />
+                    <span class="emoji">🔵</span>
+                    <span class="name">Mimos con Patas</span>
+                    <span class="price">$40</span>
+                </label>
+                <label class="package-card" data-price="30">
+                    <input type="radio" name="package" value="CARINITOS" />
+                    <span class="emoji">🟣</span>
+                    <span class="name">Cariñitos Extra</span>
+                    <span class="price">$30</span>
+                </label>
+            </div>
+        </section>
+
+        <section class="toppings">
+            <h2>Agrega toppings</h2>
+            <label class="topping-option" data-price="5">
+                <input type="checkbox" name="topping" value="Aromas" />
+                Aromas Naturales (+$5)
+            </label>
+            <label class="topping-option" data-price="10">
+                <input type="checkbox" name="topping" value="Desinfeccion" />
+                Desinfección Profunda (+$10)
+            </label>
+            <label class="topping-option" data-price="8">
+                <input type="checkbox" name="topping" value="Mascotas" />
+                Cuidado de Mascotas (+$8)
+            </label>
+        </section>
+
+        <div class="total">
+            Total: <span id="total-price">$0</span>
+        </div>
+
+        <button id="schedule-btn">Agendar mi limpieza</button>
+        <div id="message" class="hidden">¡Gracias por confiar en MELOAPP!</div>
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const packageCards = document.querySelectorAll('.package-card');
+    const toppingInputs = document.querySelectorAll('.topping-option input');
+    const totalPriceEl = document.getElementById('total-price');
+    const scheduleBtn = document.getElementById('schedule-btn');
+    const messageEl = document.getElementById('message');
+
+    let basePrice = 0;
+
+    packageCards.forEach(card => {
+        const input = card.querySelector('input');
+        input.addEventListener('change', () => {
+            packageCards.forEach(c => c.classList.remove('selected'));
+            if (input.checked) {
+                card.classList.add('selected');
+                basePrice = parseFloat(card.dataset.price);
+            }
+            updateTotal();
+        });
+    });
+
+    toppingInputs.forEach(input => {
+        input.addEventListener('change', updateTotal);
+    });
+
+    function updateTotal() {
+        let toppingTotal = 0;
+        toppingInputs.forEach(input => {
+            if (input.checked) {
+                toppingTotal += parseFloat(input.parentElement.dataset.price);
+            }
+        });
+        const total = basePrice + toppingTotal;
+        totalPriceEl.textContent = `$${total}`;
+    }
+
+    scheduleBtn.addEventListener('click', () => {
+        if (basePrice === 0) {
+            alert('Por favor selecciona un paquete.');
+            return;
+        }
+        messageEl.classList.remove('hidden');
+        setTimeout(() => messageEl.classList.add('hidden'), 3000);
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,116 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f4f4f9;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 1rem;
+}
+
+.container {
+    max-width: 600px;
+    width: 100%;
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.packages h2, .toppings h2 {
+    margin-bottom: 0.5rem;
+}
+
+.package-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.package-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: 2px solid transparent;
+    border-radius: 8px;
+    padding: 1rem;
+    background: #fff;
+    cursor: pointer;
+    transition: border-color 0.3s;
+}
+
+.package-card:hover,
+.package-card.selected {
+    border-color: #007BFF;
+}
+
+.package-card input {
+    display: none;
+}
+
+.package-card .emoji {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.package-card .price {
+    margin-top: 0.5rem;
+    font-weight: bold;
+}
+
+.toppings {
+    margin-bottom: 1rem;
+}
+
+.topping-option {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.topping-option input {
+    margin-right: 0.5rem;
+}
+
+.total {
+    font-size: 1.2rem;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+#schedule-btn {
+    width: 100%;
+    padding: 0.75rem;
+    border: none;
+    background: #007BFF;
+    color: #fff;
+    font-size: 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+#schedule-btn:hover {
+    background: #0056b3;
+}
+
+#message {
+    text-align: center;
+    margin-top: 1rem;
+    font-size: 1.1rem;
+    color: #28a745;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- update README with simulator instructions
- add HTML, JS, and CSS for cleaning package simulator

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688eb2c4e42883289f275ab671c47b3a